### PR TITLE
Adding double live region toggle for route change announcement

### DIFF
--- a/src/components/PageStatus/PageStatus.jsx
+++ b/src/components/PageStatus/PageStatus.jsx
@@ -36,7 +36,6 @@ const PageStatus = props => {
       tabIndex={isFocusable ? -1 : undefined}
     >
       <div
-<<<<<<< HEAD
         aria-atomic="true"
         aria-hidden={toggle ? undefined : 'true'}
         aria-live={isFocusable ? 'off' : 'polite'}
@@ -51,20 +50,6 @@ const PageStatus = props => {
         role={role}
       >
         {!toggle ? pageTitle : ''}
-=======
-        role="status"
-        aria-live={isFocusable ? 'off' : 'polite'}
-        aria-atomic="true"
-      >
-        {toggle ? children : ''}
-      </div>
-      <div
-        role="status"
-        aria-live={isFocusable ? 'off' : 'polite'}
-        aria-atomic="true"
-      >
-        {!toggle ? children : ''}
->>>>>>> 474bc6c90154489109c1b865861a9499ee8ca506
       </div>
     </div>
   );

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,4 @@ import './index.css';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+root.render(<App />);

--- a/src/routes/Expenses.jsx
+++ b/src/routes/Expenses.jsx
@@ -10,7 +10,7 @@ const Expenses = props => {
   return (
     <>
       <DocumentHead pageTitle={pageTitle} />
-      <PageStatus pageTitle={pageTitle} />
+      <PageStatus pageTitle={pageTitle} isFocusable />
       <SkipLink />
       <Header />
 

--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -10,7 +10,7 @@ const Home = props => {
   return (
     <>
       <DocumentHead pageTitle={pageTitle} />
-      <PageStatus pageTitle={pageTitle} />
+      <PageStatus pageTitle={pageTitle} isFocusable />
       <SkipLink />
       <Header />
 

--- a/src/routes/Invoices.jsx
+++ b/src/routes/Invoices.jsx
@@ -10,7 +10,7 @@ const Invoices = props => {
   return (
     <>
       <DocumentHead pageTitle={pageTitle} />
-      <PageStatus pageTitle={pageTitle} />
+      <PageStatus pageTitle={pageTitle} isFocusable />
       <SkipLink />
       <Header />
 

--- a/src/routes/Template.jsx
+++ b/src/routes/Template.jsx
@@ -1,5 +1,12 @@
+import { useState } from "react";
 import { Outlet } from "react-router-dom";
 
-const Template = () => <Outlet />;
+const Template = () => {
+  const [toggle, setToggle] = useState(false);
+
+  return (
+    <Outlet context={[toggle, setToggle]} />
+  );
+};
 
 export default Template;


### PR DESCRIPTION
## Summary
I have been researching multiple ways to handle client-side route change announcements to screen readers. The best way is to create a `div[role="status"]` container at the top of the DOM source order, and set focus on it on route change. I adopted [work done by an Elastic teammate](https://github.com/elastic/eui/blob/main/src/components/accessibility/screen_reader_live/screen_reader_live.tsx) on the EUI design system to include a double live region setup with a toggled state. This "juggles" the active live region to ensure consistent readback.

## Testing
* Tested for keyboard navigation. The focus is always set on the containing div, and pressing `Tab` sets focus on skip link.
* MacOS Monterey + Safari + VoiceOver
* MacOS Monterey + Firefox + VoiceOver